### PR TITLE
Fix building with GCC 10

### DIFF
--- a/data.h
+++ b/data.h
@@ -29,5 +29,5 @@ typedef struct {
 	ino_t ino;
 } WatchFile;
 
-/* declare as extern in source */
-WatchFile **files;
+/* defined in entr.c */
+extern WatchFile **files;

--- a/entr.c
+++ b/entr.c
@@ -69,7 +69,7 @@ int (*xtcsetattr)(int fd, int action, const struct termios *tp);
 /* globals */
 
 extern int optind;
-extern WatchFile **files;
+WatchFile **files;
 WatchFile *leading_edge;
 int child_pid;
 


### PR DESCRIPTION
When trying to build with gcc 10, there is a linker error:

    /usr/bin/ld: /tmp/ccjRQbpX.o:/builddir/build/BUILD/entr-4.4/data.h:33: multiple definition of `files'; /tmp/ccHpowMW.o:/builddir/build/BUILD/entr-4.4/missing/../data.h:33: first defined here
    collect2: error: ld returned 1 exit status

This is a known thing in gcc 10:

https://gcc.gnu.org/gcc-10/porting_to.html#common

"Default to -fno-common

A common mistake in C is omitting extern when declaring a global variable in a header file. If the header is included by several files it results in multiple definitions of the same variable. In previous GCC versions this error is ignored. GCC 10 defaults to -fno-common, which means a linker error will now be reported. To fix this, use extern in header files when declaring global variables, and ensure each global is defined in exactly one C file. As a workaround, legacy C code can be compiled with -fcommon.

       int x;  // tentative definition - avoid in header files

       extern int y;  // correct declaration in a header file"

This patch adds extern keyword to the header file and removes it from
exactly one source file.