### PR TITLE
Clarify the purpose and use of the WSL / Docker for Mac inotify workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ To see available build options run `./configure -h`
 Docker and Windows Subsystem for Linux
 --------------------------------------
 
-Incomplete inotify support on WSL and Docker for Mac can cause entr
-to respond inconsistently. Since version 4.4, entr includes a workaround:
+Incomplete inotify support on WSL and Docker for Mac can cause `entr`
+to respond inconsistently. Since version 4.4, `entr` includes a workaround:
 Set the environment variable `ENTR_INOTIFY_WORKAROUND`.
 
-entr will confirm the workaround is enabled:
+`entr` will confirm the workaround is enabled:
 
-```bash
+```
 entr: broken inotify workaround enabled
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ To see available build options run `./configure -h`
 Docker and Windows Subsystem for Linux
 --------------------------------------
 
-To enable a workaround for incomplete inotify support on WSL or Docker for Mac,
-set the environment variable `ENTR_INOTIFY_WORKAROUND`.
+Incomplete inotify support on WSL and Docker for Mac can cause entr
+to respond inconsistently. Since version 4.4, entr includes a workaround:
+Set the environment variable `ENTR_INOTIFY_WORKAROUND`.
+
+entr will confirm the workaround is enabled:
+
+```bash
+entr: broken inotify workaround enabled
+```
 
 Man Page Examples
 -----------------


### PR DESCRIPTION
I found entr yesterday in the course of adding hot reloading to a Docker development image but had trouble getting it to reload consistently. I found this section of the README and tried the workaround, but it didn't seem to change the behavior, so I wasn't sure if I had correctly
enabled the workaround.

entr 3.9, which I had installed from apt-get, did not yet have the workaround feature. Instead I had to build from source. I also didn't know to expect the warning entr prints when the workaround is enabled, which would have given me a way to know whether my configuration was
right.

I hope these hints reduce the barrier to entry for newcomers like me. 🕊️ 