### PR TITLE
always wait childs to avoid zombies

### DIFF
--- a/entr.c
+++ b/entr.c
@@ -254,8 +254,8 @@ void
 proc_exit(int sig) {
 	int status;
 
+	xwaitpid(child_pid, &status, 0);
 	if ((oneshot_opt == 1) && (terminating == 0)) {
-		xwaitpid(child_pid, &status, 0);
 		if ((shell_opt == 1) && (restart_opt == 0)) {
 			fprintf(stdout, "%s returned exit code %d\n",
 			    basename(getenv("SHELL")), WEXITSTATUS(status));


### PR DESCRIPTION
Since 4.5 it seems that entr no longer properly wait for childs and
every time an event is triggered it left a zombie.

To reproduce this issue...
On a first terminal, let's create a file and invoke entr:

````
% touch /tmp/testing-entr ; echo /tmp/testing-entr | ./entr sh -c 'echo $$'
````

On another terminal let's trigger the running entr:

````
% echo "foo" >> /tmp/testing-entr
% echo "foo" >> /tmp/testing-entr
% echo "foo" >> /tmp/testing-entr
````

...and finally - always on the 2nd terminal - let's inspect
corresponding entr process and its zombies:

````
% ps aux
leot       5696  0.0  0.0   16028  1368 pts/7  S+    6:59PM 0:00.00 ./entr sh -c echo $$
leot      23501  0.0  0.0       0     0 pts/7  Z+         - 0:00.00 (sh)
leot      25071  0.0  0.0       0     0 pts/7  Z+         - 0:00.00 (sh)
leot      29677  0.0  0.0       0     0 pts/7  Z+         - 0:00.00 (sh)
````