### PR TITLE
Use a closed pipe for stdin with -r

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 = Next Release: 4.6
 
+ - Fix STDIN with -r being broken
  - Always call waitpid(2) to avoid dead processes
 
 = Release History

--- a/entr.c
+++ b/entr.c
@@ -405,8 +405,7 @@ run_utility(char *argv[]) {
 	if (restart_opt == 1) {
 		terminate_utility();
 
-		ret = pipe(stdin_pipe);
-		if (ret != 0)
+		if (pipe(stdin_pipe); != 0)
 			err(1, "Failed to create stdin pipe");
 		close(stdin_pipe[1]);
 	}

--- a/entr.c
+++ b/entr.c
@@ -400,9 +400,16 @@ run_utility(char *argv[]) {
 	char **new_argv;
 	char *p, *arg_buf;
 	int argc;
+	int stdin_pipe[2];
 
-	if (restart_opt == 1)
+	if (restart_opt == 1) {
 		terminate_utility();
+
+		ret = pipe(stdin_pipe);
+		if (ret != 0)
+			err(1, "Failed to create stdin pipe");
+		close(stdin_pipe[1]);
+	}
 
 	if (shell_opt == 1) {
 		/* run argv[1] with a shell using the leading edge as $0 */
@@ -444,7 +451,7 @@ run_utility(char *argv[]) {
 		/* Set process group so subprocess can be signaled */
 		if (restart_opt == 1) {
 			setpgid(0, getpid());
-			close(STDIN_FILENO);
+			dup2(stdin_pipe[0], STDIN_FILENO);
 		}
 		/* wait up to 1 seconds for each file to become available */
 		for (i=0; i < 10; i++) {

--- a/entr.c
+++ b/entr.c
@@ -405,7 +405,7 @@ run_utility(char *argv[]) {
 	if (restart_opt == 1) {
 		terminate_utility();
 
-		if (pipe(stdin_pipe); != 0)
+		if (pipe(stdin_pipe) != 0)
 			err(1, "Failed to create stdin pipe");
 		close(stdin_pipe[1]);
 	}


### PR DESCRIPTION
Closing stdin in fork means that any attempt to use STDIN will be met with an `EBADF` IO error, instead of the intended effect: `read()` returns zero indicating EOF. Instead, this patch makes entr create a pair of pipes, immediately closing the sending end before setting the receiving end as stdin. This fixes several errors in programs when using `-r`.