### PR TITLE
add installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ automated testing natural and completely ordinary.
 Source Installation - BSD, Mac OS, and Linux
 --------------------------------------------
 
+Install make and build-essential, if not already installed. Then:
+
     ./configure
     make test
     make install


### PR DESCRIPTION
ran into error w/ WSL2 ubuntu because make and build-essential wasn't installed

```
almenon@DESKTOP-QAK2P0K:~/entr$ make test

Command 'make' not found, but can be installed with:

sudo apt install make        # version 4.2.1-1.2, or
sudo apt install make-guile  # version 4.2.1-1.2
```

```
almenon@DESKTOP-QAK2P0K:~/entr$ make install
cc  -D_GNU_SOURCE -D_LINUX_PORT -Imissing -DRELEASE=\"4.7\" missing/strlcpy.c missing/kqueue_inotify.c entr.c -o entr
make: cc: Command not found
make: *** [Makefile.bsd:20: entr] Error 127
```