### PR TITLE
Reorganize file limit detection for each platform

### DIFF
--- a/Makefile.bsd
+++ b/Makefile.bsd
@@ -1,6 +1,6 @@
 PREFIX ?= /usr/local
 MANPREFIX ?= ${PREFIX}/man
-RELEASE = 4.8
+RELEASE = 4.9
 CPPFLAGS += -DRELEASE=\"${RELEASE}\"
 
 all: versioncheck entr

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+= Next Release: 4.9
+
+ - EV_TRACE also prints file/notify descriptor limit
+ - Don't raise rlim_cur on MacOS
+ - Set 2^16 watches if inotify limits cannot be read
+
 = Release History
 
 == 4.8: February 26, 2021


### PR DESCRIPTION
Linux (including Android), MacOS and BSD all have particular rules
conditions Separate them out into three sections to make the logic for
each clear.