### PR TITLE
use size_t for strlcpy parameter

### DIFF
--- a/missing/compat.h
+++ b/missing/compat.h
@@ -6,7 +6,7 @@
 
 #if defined(_LINUX_PORT) && defined(__GLIBC__)
 #include <sys/types.h>
-size_t strlcpy(char *to, const char *from, int l);
+size_t strlcpy(char *to, const char *from, size_t l);
 #endif
 
 #if defined(_LINUX_PORT)


### PR DESCRIPTION
Fixes the following warning when compiled with gcc with LTO enabled.

```
missing/compat.h:9:8: warning: type of 'strlcpy' does not match original declaration [-Wlto-type-mismatch]
    9 | size_t strlcpy(char *to, const char *from, int l);
      |        ^
missing/strlcpy.c:28:1: note: type mismatch in parameter 3
   28 | strlcpy(char *dst, const char *src, size_t siz)
      | ^
```