### PR TITLE
Close also read end of the pipe when it is no longer needed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 = Next Release: 5.3
 
  - Symlink changes detected on Linux by setting 'ENTR_INOTIFY_SYMLINK'
+ - Close read end of the pipe when it is no longer needed in -r mode, which
+   prevents file descriptors exhaustion.
 
 = Release History
 

--- a/entr.c
+++ b/entr.c
@@ -496,6 +496,7 @@ run_utility(char *argv[]) {
 		if (restart_opt == 1) {
 			setpgid(0, getpid());
 			dup2(stdin_pipe[0], STDIN_FILENO);
+			close(stdin_pipe[0]);
 		}
 		/* wait up to 1 seconds for each file to become available */
 		for (i=0; i < 10; i++) {
@@ -508,6 +509,9 @@ run_utility(char *argv[]) {
 			err(1, "exec %s", new_argv[0]);
 	}
 	child_pid = pid;
+
+	if (restart_opt == 1)
+		close(stdin_pipe[0]);
 
 	if (restart_opt == 0 && oneshot_opt == 0) {
 		if (wait(&status) != -1)


### PR DESCRIPTION
entr creates pipe in an -r mode to a child process, however, the read
end of the pipe needs to be closed in parent process after fork,
otherwise file descriptors will be exhausted after some time and enter
will die with an error:

   entr: Failed to create stdin pipe: No file descriptors available

Additionally, it is also common to close read end of the pipe in child
process after it was duplicated to standard input file descriptor.

Fixes: 7c89dfb2b442 ("Use a closed pipe for stdin with -r")

---

The issue can be easily reproduce by setting number of file descriptors limit to lower number, running `entr` in `-r` mode and hitting the `space` button. For example, in linux:
```sh
ulimit -n 16
echo entr | ./entr -r date
```