### PR TITLE
Set FD_CLOEXEC for kqueue descriptor

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@
  - Symlink changes detected on Linux by setting 'ENTR_INOTIFY_SYMLINK'
  - Close read end of the pipe when it is no longer needed in -r mode, which
    prevents file descriptors exhaustion.
+ - Utilize {O,FD}_CLOEXEC flag for unintentional leaks of descriptors to
+   executed utilities
 
 = Release History
 

--- a/entr.c
+++ b/entr.c
@@ -540,9 +540,9 @@ watch_file(int kq, WatchFile *file) {
 	/* wait up to 1 second for file to become available */
 	for (i=0; i < 10; i++) {
 		#ifdef O_EVTONLY
-		file->fd = xopen(file->fn, O_RDONLY|O_EVTONLY);
+		file->fd = xopen(file->fn, O_RDONLY|O_CLOEXEC|O_EVTONLY);
 		#else
-		file->fd = xopen(file->fn, O_RDONLY);
+		file->fd = xopen(file->fn, O_RDONLY|O_CLOEXEC);
 		#endif
 		if (file->fd == -1) nanosleep(&delay, NULL);
 		else break;

--- a/entr.c
+++ b/entr.c
@@ -197,6 +197,9 @@ main(int argc, char *argv[]) {
 	if ((kq = kqueue()) == -1)
 		err(1, "cannot create kqueue");
 
+	if (fcntl(kq, F_SETFD, FD_CLOEXEC) == -1)
+		warn("failed to set FD_CLOEXEC to kqueue descriptor");
+
 	/* expect file list from a pipe */
 	if (isatty(fileno(stdin)))
 		usage();


### PR DESCRIPTION
There seems to be no reason why this descriptor should be preserved to child processes.

However, I am not sure if this change is compatible with all implementations of `kqueue`. I tested it in linux. It would be also possible to change `inotify_init()` to `inotify_init1(IN_CLOEXEC)` in `missing/kqueue_inotify.c` if this will not work in *BSDs.