### PR TITLE
system_test: Use command -v rather than which

### DIFF
--- a/system_test.sh
+++ b/system_test.sh
@@ -40,7 +40,7 @@ trap "$clear_tty; $clear_tmux; $clear_tmp" EXIT
 
 utils="file pgrep git vim tmux"
 for util in $utils; do
-	p=$(which $util 2> /dev/null) || {
+	p=$(command -pv $util) || {
 		echo "ERROR: could not locate the '$util' utility" >&2
 		echo "System tests depend on the following: $utils" >&2
 		exit 1


### PR DESCRIPTION
`which` is not listed as a required command by POSIX, and it is entirely superficial on any system with POSIX shell, unlike `command -v` which is usually available as a built-in command of shell.

This contribution is motivated by https://bugs.gentoo.org/646588.