### PR TITLE
system_test: configure git email address locally

### DIFF
--- a/system_test.sh
+++ b/system_test.sh
@@ -250,6 +250,7 @@ try "exec single utility when an entire stash of files is reverted"
 		cp /usr/include/*.h $tmp/
 		cd $tmp
 		git init -q
+		git config --local user.email entr.test@example.com
 		git add *.h
 		git commit -m "initial checkin" -q
 		for f in `ls *.h | head`; do


### PR DESCRIPTION
Configuring git email address locally will avoid situations similar to one described in issue comment [1], when git email address is not configured globally. It might be impractical or not easily possible to set it globally. This will make the git test more robust.

[1] https://github.com/eradman/entr/issues/104#issuecomment-1334215299