### PR TITLE
Set IN_CLOEXEC only for inotify_init

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 = Next Release: 5.4
 
  - 'make test' runs a quick smoketest, 'make check' runs regressions
+ - Set IN_CLOEXEC only for inotify_init, kqueue uses similar setting by default
 
 = Release History
 

--- a/entr.c
+++ b/entr.c
@@ -161,9 +161,6 @@ main(int argc, char *argv[]) {
 	if ((kq = kqueue()) == -1)
 		err(1, "cannot create kqueue");
 
-	if (fcntl(kq, F_SETFD, FD_CLOEXEC) == -1)
-		warn("failed to set FD_CLOEXEC to kqueue descriptor");
-
 	/* expect file list from a pipe */
 	if (isatty(fileno(stdin)))
 		usage();

--- a/missing/kqueue_inotify.c
+++ b/missing/kqueue_inotify.c
@@ -91,7 +91,7 @@ kqueue(void) {
 	static int inotify_queue;
 
 	if (inotify_queue == 0)
-		inotify_queue = inotify_init();
+		inotify_queue = inotify_init1(IN_CLOEXEC);
 	if (getenv("ENTR_INOTIFY_WORKAROUND"))
 		warnx("broken inotify workaround enabled");
 	else if (getenv("ENTR_INOTIFY_SYMLINK"))


### PR DESCRIPTION
The returned file descriptor from `kqueue(2)` is not going to be leaked to child processes according to multiple BSDs man pages, quote from FreeBSD:

>  The queue is not inherited by a child created with fork(2).
>  Similarly, kqueues cannot be passed across UNIX-domain sockets.

This is different behavior from `inotify_init` which allows to inherit returned file descriptor by default.

Proposed change, removes `fcntl(kq, F_SETFD, FD_CLOEXEC)` introduced in commit 4b1dc5957d9c - `Set FD_CLOEXEC for kqueue and and files with O_CLOEXEC` but uses `inotify_init1(IN_CLOEXEC)` instead of `inotify_init()`, which will work with the same result.