### PR TITLE
Sync the README with the man page examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Man Page Examples
 
 Rebuild a project if source files change, limiting output to the first 20 lines:
 
-    $ find src/ | entr sh -c 'make | head -n 20'
+    $ find src/ | entr -s 'make | head -n 20'
 
 Launch and auto-reload a node.js server:
 

--- a/entr.1
+++ b/entr.1
@@ -165,7 +165,7 @@ A file was added to a directory and the directory watch option was specified
 .Sh EXAMPLES
 Rebuild a project if source files change, limiting output to the first 20 lines:
 .Pp
-.Dl $ find src/ | entr -s 'make | sed 20q'
+.Dl $ find src/ | entr -s 'make | head -n 20'
 .Pp
 Launch and auto-reload a node.js server:
 .Pp


### PR DESCRIPTION
I'm assuming the use of `-s` from the man page is newer and preferable to the README's `sh -c "..."` formulation.

Conversely, I retained the use of `head -n 20` from the README, rather than the man page's `sed 20q`, figuring that the operation of `head` is likely to be familiar to more readers.

(This nitpicking sync is a precursor to a follow-up submission which will propose adding a tiny amount of explanatory verbiage to this documentation.)