### PR TITLE
Try to increase open file limit on macOS

### DIFF
--- a/entr.c
+++ b/entr.c
@@ -135,8 +135,13 @@ main(int argc, char *argv[]) {
 		err(1, "getrlimit");
 	/* guard against unrealistic replies */
 	open_max = min(65536, (unsigned)rl.rlim_cur);
-	if (open_max == 0)
-		open_max = 65536;
+	/* try to increase the limit */
+	if (open_max < 65536) {
+		rl.rlim_cur = (rlim_t)65536;
+		if (setrlimit(RLIMIT_NOFILE, &rl) == 0 || open_max == 0) {
+			open_max = 65536;
+		}
+	}
 #else /* BSD */
 	if (getrlimit(RLIMIT_NOFILE, &rl) == -1)
 		err(1, "getrlimit");


### PR DESCRIPTION
Contrary to the information on [eradman.com](https://eradman.com/entrproject/limits.html), it's actually not necessary to use launchctl to increase the system-wide limit on the latest version of macOS. 

The hard limit is in fact unlimited and the session limit can be increased using `ulimit -n 65536`.

This PR tries to automatically increase the limit from the default `256`.