### PR TITLE
Add TARGET_OS configuration option

### DIFF
--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@ copy_mk() {
     echo "$cmd"; $cmd
 }
 
-case `uname` in
+case "${TARGET_OS:-`uname`}" in
     Darwin) copy_mk macos ;;
     Linux)  copy_mk linux ;;
     *)      copy_mk bsd ;;


### PR DESCRIPTION
This makes cross-compilation possible (e.g. `TARGET_OS=Linux ./configure` from MacOS). 