### PR TITLE
Allow custom status message to be defined

### DIFF
--- a/entr.1
+++ b/entr.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 17, 2023
+.Dd January 26, 2024
 .Dt ENTR 1
 .Os
 .Sh NAME
@@ -126,6 +126,11 @@ Quit; equivalent pressing
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width "ENTR_ENVIRON"
+.It ENTR_STATUS_COMMAND
+A command be be executed by after the the utility terminates.
+The exit status of the utility is available in the
+.Ev EXIT_STATUS
+environment variable.
 .It Ev PAGER
 Set to
 .Pa /bin/cat

--- a/system_test.sh
+++ b/system_test.sh
@@ -115,6 +115,14 @@ try "exec a command using one-shot and shell options and return signal"
 	assert "$?" "137"
 	assert "$(tail -c23  $tmp/exec.out)" "$(printf "terminated by signal 9\n")"
 
+try "exec a command using one-shot and custom shell status"
+	export ENTR_STATUS_COMMAND='echo "== $EXIT_STATUS =="'
+	setup
+	ls $tmp/file2 | ./entr -z -s 'exit 2' >$tmp/exec.out 2>$tmp/exec.err
+	assert "$?" "2"
+	assert "$(tail -c23  $tmp/exec.out)" "$(printf "== 2 ==\n")"
+	unset ENTR_STATUS_COMMAND
+
 try "fail to exec a command using one-shot option"
 	setup
 	ls $tmp/file* | ./entr -z /usr/bin/false_X 2>$tmp/exec.err


### PR DESCRIPTION
ENTR_STATUS_COMMAND is evaluated by the interpreter specified by SHELL. Takes effect with or without the shell-option (`-s`)

As before, no status message is printed in conjunction with the restart (`-r`) option.