### PR TITLE
Misc typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -209,7 +209,7 @@
  - Changed function pointer prefixes from '_' to 'x' to avoid runtime symbol
    collisions in libc. Required to build on DragonFlyBSD
  - Add this NEWS file to provide detailed release history for port maintainers
- - Subsitute '/_' argument with the first file that changed
+ - Substitute '/_' argument with the first file that changed
  - Man page formatted with more semantically correct markup
  - Multiple events on the same file are merged on Linux to prevent duplicate
    writes to a named pipe

--- a/entr.c
+++ b/entr.c
@@ -438,7 +438,7 @@ run_utility(char *argv[]) {
 	}
 	else {
 		/* clone argv on each invocation to make the implementation of more
-		 * complex subsitution rules possible and easy
+		 * complex substitution rules possible and easy
 		 */
 		for (argc=0; argv[argc]; argc++);
 		arg_buf = malloc(ARG_MAX);


### PR DESCRIPTION
This has been as a patch in Debian for a while and should be fixed upstream instead: https://sources.debian.org/src/entr/5.5-1/debian/patches/fix-spelling.patch/