### PR TITLE
Process exit status messages using background awk scripts

### DIFF
--- a/Makefile.bsd
+++ b/Makefile.bsd
@@ -1,7 +1,7 @@
 PREFIX ?= /usr/local
 MANPREFIX ?= ${PREFIX}/man
 RELEASE = 5.5
-COMPONENTS = compat.o entr.o
+COMPONENTS = compat.o status.o entr.o
 
 all: entr
 

--- a/entr.1
+++ b/entr.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 17, 2023
+.Dd February 2, 2024
 .Dt ENTR 1
 .Os
 .Sh NAME
@@ -21,7 +21,7 @@
 .Nd run arbitrary commands when files change
 .Sh SYNOPSIS
 .Nm
-.Op Fl acdnprsz
+.Op Fl acdnprsxz
 .Ar utility
 .Op Ar argument /_ ...
 .Sh DESCRIPTION
@@ -88,8 +88,19 @@ Control of the TTY is not transferred to the child process.
 Evaluate the first argument using the interpreter specified by the
 .Ev SHELL
 environment variable.
-If standard output is a TTY, the name of the shell and exit code is printed
-after each invocation.
+.It Fl x
+Format custom exit status messages using a persistent
+.Xr awk 1
+process.
+The path to the status script is defined by the environment variable
+.Ev ENTR_STATUS_SCRIPT .
+If the status script does not exist,
+.Nm
+will create an example.
+Shell commands and file redirection is not permitted by default, but may be
+enabled by specifying
+.Fl x
+twice.
 .It Fl z
 Exit after the
 .Ar utility
@@ -126,6 +137,13 @@ Quit; equivalent pressing
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width "ENTR_ENVIRON"
+.It Ev ENTR_STATUS_SCRIPT
+The path to the exit status script enabled by the
+.Fl x
+option.
+By default
+.Pa $HOME/.entr/status.awk
+is evaluated.
 .It Ev PAGER
 Set to
 .Pa /bin/cat

--- a/status.c
+++ b/status.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024 Eric Radman <ericshane@eradman.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <err.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <limits.h>
+#include <pwd.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/stat.h>
+
+#include "status.h"
+
+/* globals */
+int status_stdin_pipe[2];
+
+void
+start_log_filter(int safe) {
+	char *argv[5];
+	char *awk_script;
+	struct passwd *pw;
+
+	awk_script = getenv("ENTR_STATUS_SCRIPT");
+	if ((!awk_script) || (strlen(awk_script) == 0)) {
+		pw = getpwuid(getuid());
+		asprintf(&awk_script, "%s/.entr/status.awk", pw->pw_dir);
+	}
+
+	create_dir(xdirname(awk_script));
+	install_file(awk_script,
+	    "# http://eradman.com/entrproject/status-filters.html\n"
+	    "/^signal/ { print $3, \"terminated by signal\", $2; }\n"
+	    "/^exit/ { print $3, \"returned exit code\", $2; }\n");
+
+	argv[0] = "/usr/bin/awk";
+	argv[1] = "-f";
+	argv[2] = awk_script;
+#if defined(_LINUX_PORT)
+	argv[3] = "-S";
+#else
+	argv[3] = "-safe";
+#endif
+	argv[4] = NULL;
+	if (safe == 2)
+		argv[3] = NULL;
+
+	pipe(status_stdin_pipe);
+	status_pid = fork();
+	if (status_pid == -1)
+		err(1, "fork");
+
+	if (status_pid == 0) {
+		close(status_stdin_pipe[1]);
+		dup2(status_stdin_pipe[0], STDIN_FILENO);
+		execvp("awk", argv);
+		err(1, "could not exec %s", argv[0]);
+	}
+	close(status_stdin_pipe[0]);
+}
+
+void
+write_log_filter(char *input, size_t len) {
+	if (write(status_stdin_pipe[1], input, len) == -1)
+		err(1, "write to child");
+}
+
+void
+end_log_filter() {
+	close(status_stdin_pipe[1]);
+	kill(status_pid, SIGKILL);
+}
+
+
+/*
+ * xdirname - mimic dirname(3) on OpenBSD which does not modify input
+ * create_dir - ensure a directory exists
+ * install_file - create file is it does not exist
+ */
+
+char *
+xdirname(const char *path) {
+	static char dname[PATH_MAX];
+
+	strlcpy(dname, path, sizeof(dname));
+	return dirname(dname);
+}
+
+void
+create_dir(const char *dir) {
+	struct stat dst_sb;
+
+	if (stat(dir, &dst_sb) == -1)
+		mkdir(dir, 0750);
+}
+
+void
+install_file(const char *dst, const char *content) {
+	int fd;
+	struct stat dst_sb;
+
+	if (stat(dst, &dst_sb) == -1) {
+		printf("entr: created '%s'\n", dst);
+		fd = open(dst, O_WRONLY|O_CREAT, 0640);
+		if (fd == -1)
+			err(1, "open");
+		if (write(fd, content, strlen(content)) == -1)
+			err(1, "write");
+		close(fd);
+	}
+}

--- a/status.h
+++ b/status.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Eric Radman <ericshane@eradman.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+void start_log_filter(int safe);
+void write_log_filter(char *input, size_t len);
+void end_log_filter();
+char *xdirname(const char *path);
+void create_dir(const char *dir);
+void install_file(const char *dst, const char *content);
+
+extern pid_t status_pid;


### PR DESCRIPTION
**Examples**

http://eradman.com/entrproject/status-filters.html

**New Features**

* `-x` option enables custom status script
* Status path is defined by `ENTR_STATUS_SCRIPT` (default path is `$HOME/.entr/status.awk`)
* Example status scripted created if it does not exist
* Abort if the status process terminates for any reason

**Message Format**

>  exit_type exit_code utility_name

**Changes to Existing Behavior**

* shell (`-s`) option no longer prints a status by default

**Caveats**

* Not compatible with restart (`-r`) option
* gawk required on Alpine, or use `-xx` to allow unsafe operation