### PR TITLE
Always use non-interactive mode if no tty detected

### DIFF
--- a/entr.c
+++ b/entr.c
@@ -401,6 +401,11 @@ set_options(char *argv[]) {
 	int ch;
 	int argc;
 
+	/* Automatically run non-interactive none of standard in, out or error is a tty */
+	if (!isatty(STDIN_FILENO) && !isatty(STDOUT_FILENO) && !isatty(STDERR_FILENO)) {
+		noninteractive_opt = 1;
+	}
+
 	/* read arguments until we reach a command */
 	for (argc=1; argv[argc] != 0 && argv[argc][0] == '-'; argc++);
 	while ((ch = getopt(argc, argv, "acdnprsxz")) != -1) {


### PR DESCRIPTION
Running the system_tests.sh in Debian CI or elsewhere in an automated fashion without and interactive terminal resulted in error like:

  FAIL: install default status script

Automatically detect presence of a tty and ensure entr behaves accordingly.