### PR TITLE
Expand aliases in shell script system_test.sh

### DIFF
--- a/system_test.sh
+++ b/system_test.sh
@@ -66,9 +66,11 @@ if [ $(uname) == 'Linux' ]; then
 fi
 
 # local binary, non-interactive by default
-
 alias entr='./entr -n'
 alias entr_tty='./entr'
+
+# alias expansion is not enabled by default in non-interactive Bourne Again Shell (bash) sessions
+command -v shopt > /dev/null && shopt -s expand_aliases
 
 # fast tests
 


### PR DESCRIPTION
By default shell/bash does not use aliases. This can be verified by running 'alias' after any alias setting commands, and see that it is empty.

Activate shell option expand_aliases for the following alias lines to work correctly.