### PR TITLE
Ensure tmux(1) runs with a valid shell

### DIFF
--- a/system_test.sh
+++ b/system_test.sh
@@ -179,7 +179,7 @@ unset TMUX
 
 try "spacebar triggers utility"
 	setup
-	tmux new-session -s $tsession -d
+	env SHELL=/bin/sh tmux new-session -s $tsession -d
 	echo "waiting" > $tmp/file1
 	echo "finished" > $tmp/file2
 	tmux send-keys -t $tsession:0 \


### PR DESCRIPTION
At least on OpenBSD, ports tests run as unprivileged _pbuild user whose
shell is set to nologin(8), thus causing tmux to fail (#151) and skip
all further tests (#150).

tmux prefers the environment's SHELL to the user's login shell;
set that to make all 49 tests pass on OpenBSD.

For the trivial tmux use case, /bin/sh should suffice on all other
systems.

Fix #151
