### PR TITLE
Always accept directories as input

### DIFF
--- a/entr.1
+++ b/entr.1
@@ -52,11 +52,9 @@ Clear the screen before invoking the
 specified on the command line.
 Specify twice to erase the scrollback buffer.
 .It Fl d
-Track the directories of regular files provided as input and exit if a new file
-is added.
-This option also enables directories to be specified explicitly.
-If specified twice, all new entries to a directory are recognized,
-otherwise files with names beginning with
+Track the parent directory of regular files provided as input.
+If specified twice, all new entries to a directory are recognized, otherwise
+files with names beginning with
 .Ql \&.
 are ignored.
 .It Fl n
@@ -178,7 +176,7 @@ Normal termination after receiving
 .It 1
 No regular files were provided as input or an error occurred
 .It 2
-A file was added to a directory and the directory watch option was specified
+Files were added or removed from a directory
 .El
 .Sh EXAMPLES
 Rebuild a project if source files change, limiting output to the first 20 lines:
@@ -195,7 +193,7 @@ Clear the screen and run a query after the SQL script is updated:
 .Pp
 Rebuild project if a source file is modified or added to the src/ directory:
 .Pp
-.Dl $ while sleep 0.1; do ls src/*.rb | entr -d make; done
+.Dl $ while sleep 0.1; do ls -d src src/*.rb | entr make; done
 .Pp
 Auto-reload a web server, or terminate if the server exits
 .Pp

--- a/entr.c
+++ b/entr.c
@@ -331,7 +331,7 @@ print_child_status(int status) {
 int
 process_input(FILE *file, WatchFile *files[], int max_files) {
 	char buf[PATH_MAX];
-	char *p, *path;
+	char *p, *path, *parent_path;
 	int n_files = 0;
 	struct stat sb;
 	int i, matches;
@@ -341,38 +341,45 @@ process_input(FILE *file, WatchFile *files[], int max_files) {
 			*p = '\0';
 		if (buf[0] == '\0')
 			continue;
+		path = &buf[0];
 
-		if (stat(buf, &sb) == -1) {
-			warnx("unable to stat '%s'", buf);
+		if (stat(path, &sb) == -1) {
+			warnx("unable to stat '%s'", path);
 			continue;
 		}
+
 		if (S_ISREG(sb.st_mode) != 0) {
 			files[n_files] = malloc(sizeof(WatchFile));
-			strlcpy(files[n_files]->fn, buf, MEMBER_SIZE(WatchFile, fn));
+			strlcpy(files[n_files]->fn, path, MEMBER_SIZE(WatchFile, fn));
 			files[n_files]->is_dir = 0;
 			files[n_files]->file_count = 0;
 			files[n_files]->mode = sb.st_mode;
 			files[n_files]->ino = sb.st_ino;
 			n_files++;
-		}
-		/* also watch the directory if it's not already in the list */
-		if (dirwatch_opt > 0) {
-			if (S_ISDIR(sb.st_mode) != 0)
-				path = &buf[0];
-			else if ((path = dirname(buf)) == 0)
-				err(1, "dirname '%s' failed", buf);
-			for (matches = 0, i = 0; i < n_files; i++)
-				if (strcmp(files[i]->fn, path) == 0)
-					matches++;
-			if (matches == 0) {
-				files[n_files] = malloc(sizeof(WatchFile));
-				strlcpy(files[n_files]->fn, path, MEMBER_SIZE(WatchFile, fn));
-				files[n_files]->is_dir = 1;
-				files[n_files]->file_count = list_dir(path);
-				files[n_files]->mode = sb.st_mode;
-				files[n_files]->ino = sb.st_ino;
-				n_files++;
+
+			/* also watch the directory if it's not already in the list */
+			if (dirwatch_opt > 0) {
+				if ((parent_path = dirname(path)) == 0)
+					err(1, "dirname '%s' failed", path);
+				for (matches = 0, i = 0; i < n_files; i++) {
+					if ((files[i]->is_dir == 1) && (strcmp(files[i]->fn, parent_path) == 0))
+						matches++;
+				}
+				if (matches == 0) {
+					if (stat(parent_path, &sb) == -1)
+						warnx("unable to stat '%s'", parent_path);
+					path = parent_path;
+				}
 			}
+		}
+		if (S_ISDIR(sb.st_mode) != 0) {
+			files[n_files] = malloc(sizeof(WatchFile));
+			strlcpy(files[n_files]->fn, path, MEMBER_SIZE(WatchFile, fn));
+			files[n_files]->is_dir = 1;
+			files[n_files]->file_count = list_dir(path);
+			files[n_files]->mode = sb.st_mode;
+			files[n_files]->ino = sb.st_ino;
+			n_files++;
 		}
 		if (n_files + 1 > max_files)
 			return -1;

--- a/system_test.sh
+++ b/system_test.sh
@@ -286,7 +286,7 @@ try "exec single shell utility and exit when a hidden subdirectory is added"
 
 try "exec single shell utility and exit when a file is added to a specific path"
 	setup
-	ls -d $tmp | entr -dp sh -c 'echo ping' >$tmp/exec.out 2>$tmp/exec.err \
+	ls -d $tmp | entr -p sh -c 'echo ping' >$tmp/exec.out 2>$tmp/exec.err \
 	    || true &
 	bgpid=$! ; zz
 	touch $tmp/newfile


### PR DESCRIPTION
This makes the `-d` flag optional.  Implicitly monitoring directories is sometimes convenient, but it has two problems:

- Some directories may be monitored by accident, and there is no way to opt-out.
- Directories without any matching files are silently skipped from monitoring.  This condition is difficult to detect.