### PR TITLE
Monitor symlinks on Linux and MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Incomplete inotify support on _Windows Subsystem for Linux_ and _Docker for Mac_
 may cause `entr` to respond incorrectly. Setting the environment variable
 `ENTR_INOTIFY_WORKAROUND` enables `entr` to operate in these environments.
 
-Linux Features
---------------
+Platform Features
+-----------------
 
-Symlinks can be monitored for changes by setting the environment variable
-`ENTR_INOTIFY_SYMLINK`.
+On Mac OS and Linux, symlinks are not followed unless the environment variable
+`ENTR_FOLLOW_SYMLINK` is set.
 
 Man Page Examples
 -----------------

--- a/data.h
+++ b/data.h
@@ -24,6 +24,7 @@ typedef struct {
 	char fn[PATH_MAX];
 	int fd;
 	int is_dir;
+	int is_symlink;
 	int file_count;
 	mode_t mode;
 	ino_t ino;

--- a/missing/kqueue_inotify.c
+++ b/missing/kqueue_inotify.c
@@ -150,7 +150,7 @@ kevent(int kq, const struct kevent *changelist, int nchanges, struct kevent *eve
 			} else if (kev->flags & EV_ADD) {
 				if (getenv("ENTR_INOTIFY_WORKAROUND"))
 					wd = inotify_add_watch(kq, file->fn, IN_ALL | IN_MODIFY);
-				else if (getenv("ENTR_INOTIFY_SYMLINK"))
+				else if (file->is_symlink)
 					wd = inotify_add_watch(kq, file->fn, IN_ALL | IN_DONT_FOLLOW);
 				else
 					wd = inotify_add_watch(kq, file->fn, IN_ALL);


### PR DESCRIPTION
Symlinks do not need to have a valid target.  To disable this behavior set `ENTR_FOLLOW_SYMLINK`.

OpenBSD and FreeBSD do not have an monitor-only flags for open(2), so symlinks are always followed.

