### PR TITLE
Add return value check for library function

### DIFF
--- a/entr.c
+++ b/entr.c
@@ -197,7 +197,7 @@ main(int argc, char *argv[]) {
 	/* sequential scan may depend on a 0 at the end */
 	files = calloc(open_max + 1, sizeof(WatchFile *));
 	if (files == NULL)
-		err(1, "unable to allocate memory for file list");
+		err(1, "calloc");
 
 	if ((kq = kqueue()) == -1)
 		err(1, "cannot create kqueue");
@@ -389,7 +389,7 @@ process_input(FILE *file, WatchFile *files[], int max_files) {
 		if ((S_ISREG(sb.st_mode) | S_ISLNK(sb.st_mode)) != 0) {
 			files[n_files] = malloc(sizeof(WatchFile));
 			if (files[n_files] == NULL)
-				err(1, "unable to allocate memory for the file");
+				err(1, "malloc");
 			strlcpy(files[n_files]->fn, path, MEMBER_SIZE(WatchFile, fn));
 			files[n_files]->is_dir = 0;
 			files[n_files]->is_symlink = (S_ISLNK(sb.st_mode) != 0) ? 1 : 0;
@@ -416,7 +416,7 @@ process_input(FILE *file, WatchFile *files[], int max_files) {
 		if (S_ISDIR(sb.st_mode) != 0) {
 			files[n_files] = malloc(sizeof(WatchFile));
 			if (files[n_files] == NULL)
-				err(1, "unable to allocate memory for the file");
+				err(1, "malloc");
 			strlcpy(files[n_files]->fn, path, MEMBER_SIZE(WatchFile, fn));
 			files[n_files]->is_dir = 1;
 			files[n_files]->is_symlink = 0;
@@ -527,7 +527,7 @@ run_utility(char *argv[]) {
 		argc = 4;
 		new_argv = calloc(argc + 1, sizeof(char *));
 		if (new_argv == NULL)
-			err(1, "unable to allocate memory for argument list");
+			err(1, "calloc");
 		new_argv[0] = shell;
 		new_argv[1] = "-c";
 		new_argv[2] = argv[0];
@@ -540,7 +540,7 @@ run_utility(char *argv[]) {
 			;
 		new_argv = calloc(argc + 1, sizeof(char *));
 		if (new_argv == NULL)
-			err(1, "unable to allocate memory for argument list");
+			err(1, "calloc");
 		for (m = 0, i = 0, p = arg_buf; i < argc; i++) {
 			remaining = ARG_MAX - (p - arg_buf);
 			new_argv[i] = p;

--- a/status.c
+++ b/status.c
@@ -44,7 +44,7 @@ start_log_filter(int safe) {
 	if ((!awk_script) || (strlen(awk_script) == 0)) {
 		pw = getpwuid(getuid());
 		if (pw == NULL)
-			errx(1, "getpwuid failed");
+			errx(1, "getpwuid");
 		asprintf(&awk_script, "%s/.entr/status.awk", pw->pw_dir);
 	}
 


### PR DESCRIPTION
`malloc`, `calloc ', `pipe`, and `getpwuid`  have the potential risk of failing.
Once the operation fails, it will cause bug like NULL Pointer Dereference.
This pr means to fix these potential bugs by adding the return value check.