### PR TITLE
Add '-h' flag to display usage summery of each option

### DIFF
--- a/system_test.sh
+++ b/system_test.sh
@@ -62,8 +62,18 @@ command -v shopt > /dev/null && shopt -s expand_aliases
 # fast tests
 
 try "no arguments"
-	entr 2> /dev/null || code=$?
-	assert $code 1
+	entr >$tmp/exec.out 2>$tmp/exec.err
+	assert $? 1
+	grep -q "usage:" $tmp/exec.err
+	assert $? 0
+
+try "display option summary"
+	entr_tty -h >$tmp/exec.out 2>$tmp/exec.err
+	assert $? 1
+	grep -q "usage:" $tmp/exec.err
+	assert $? 0
+	grep -q "summary:" $tmp/exec.out
+	assert $? 0
 
 try "no input"
 	echo | entr echo "vroom" 2> /dev/null || code=$?


### PR DESCRIPTION
Inspired by the usage summary displayed by busybox utilities, and others such as `ffmpeg` that provide a hint

```
$ entr
release: 5.7
usage: entr [-acdnprsxz] utility [argument [/_] ...] < filenames
hint: use -h to display option summary
```

```
$ entr -h
release: 5.7
usage: entr [-acdnprsxz] utility [argument [/_] ...] < filenames
summary:
    -a  Do not consolidate events
    -c  Clear screen before execution
    -d  Track files added or removed from directories
    -n  Non-interactive mode
    -p  Wait for first event
    -r  Run as a background process, use signal to restart
    -s  Evaluate using a shell
    -x  Format exit status
    -z  Exit after the utility completes
docs:
    man entr
```