### PR TITLE
fix: correctly calculate maxfiles on macos

### DIFF
--- a/missing/compat.h
+++ b/missing/compat.h
@@ -10,6 +10,10 @@ size_t strlcpy(char *dst, const char *src, size_t dsize);
 int fs_sysctl(const int name);
 #endif
 
+#if defined(_MACOS_PORT)
+int macos_sysctl_maxfiles(void);
+#endif
+
 #if !defined(ARG_MAX)
 #define ARG_MAX (256 * 1024)
 #endif


### PR DESCRIPTION
The Mac implementation was previously using OPEN_MAX as an absolute maximum number of open files. This was wrong -- this is no longer a static config, so a proper solution needs to look up the actual limit.