### PR TITLE
MacOS: set open_max limit using MAXFILESPERPROC

### DIFF
--- a/missing/compat.h
+++ b/missing/compat.h
@@ -10,6 +10,10 @@ size_t strlcpy(char *dst, const char *src, size_t dsize);
 int fs_sysctl(const int name);
 #endif
 
+#if defined(_MACOS_PORT)
+int macos_sysctl_maxfiles(void);
+#endif
+
 #if !defined(ARG_MAX)
 #define ARG_MAX (256 * 1024)
 #endif

--- a/missing/compat.h
+++ b/missing/compat.h
@@ -10,10 +10,6 @@ size_t strlcpy(char *dst, const char *src, size_t dsize);
 int fs_sysctl(const int name);
 #endif
 
-#if defined(_MACOS_PORT)
-int macos_sysctl_maxfiles(void);
-#endif
-
 #if !defined(ARG_MAX)
 #define ARG_MAX (256 * 1024)
 #endif

--- a/missing/sys/sysctl.h
+++ b/missing/sys/sysctl.h
@@ -1,0 +1,1 @@
+/* empty unit: sysctl(2) not called on Linux */


### PR DESCRIPTION
* If sysctl(2) fails use `OPEN_MAX`
* stub `sys/sysctl.h` on Linux
